### PR TITLE
Check for dependency lock files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       - run: npm i -g bun@1
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/.github/workflows/eas-preview.yml
+++ b/.github/workflows/eas-preview.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-      - run: npm ci
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile
       - run: npm i -g eas-cli
       - name: Login to Expo
         run: eas whoami || eas login --token ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/eas-release.yml
+++ b/.github/workflows/eas-release.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-      - run: npm ci
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile
       - run: npm i -g eas-cli
       - name: Login to Expo
         run: eas whoami || eas login --token ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install Bun
         run: npm i -g bun@1


### PR DESCRIPTION
Update GitHub Actions workflows to correctly use Bun for dependency management and caching.

The previous configuration used `cache: 'npm'` and `npm ci`, which caused "Dependencies lock file is not found" errors because the project relies on `bun.lock` for dependency management.

---
<a href="https://cursor.com/background-agent?bcId=bc-631ded12-8268-4735-a32c-7ee69d1a2668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-631ded12-8268-4735-a32c-7ee69d1a2668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

