### PR TITLE
Update github token for pull request scans

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-path: .gitleaks.toml
           redact: true
           sarif-file-output: gitleaks.sarif

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -169,8 +169,9 @@ EOF
       - name: 🔐 Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # Security summary
   security-summary:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -134,9 +134,9 @@ jobs:
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: --config-path=.gitleaks.toml --redact --verbose
   security-summary:
     name: Security Summary


### PR DESCRIPTION
Update Gitleaks GitHub Actions workflows to pass `GITHUB_TOKEN` as a `token` parameter in the `with` section, resolving recent breaking changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3476f76-ebce-420a-be66-860681a8a985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3476f76-ebce-420a-be66-860681a8a985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflows to use an explicit token input instead of an environment variable for authentication.
  * Enabled verbose logging for Gitleaks to improve scan transparency.
  * Aligned token handling consistently across all security-related workflows.
  * No functional changes to application behavior; improvements are limited to CI security scan configuration and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->